### PR TITLE
tr - add PUT (update) method for RosterStudent Controller

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
@@ -34,6 +34,7 @@ import edu.ucsb.cs156.frontiers.enums.RosterStatus;
 import edu.ucsb.cs156.frontiers.errors.EntityNotFoundException;
 import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
 import edu.ucsb.cs156.frontiers.repositories.RosterStudentRepository;
+import edu.ucsb.cs156.frontiers.dto.RosterStudentUpdateDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -41,6 +42,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import com.opencsv.CSVReader;
 import com.opencsv.exceptions.CsvException;
+
+import jakarta.validation.Valid;
 
 @Tag(name = "RosterStudents")
 @RequestMapping("/api/rosterstudents")
@@ -118,6 +121,37 @@ public class RosterStudentsController extends ApiController {
         courseRepository.findById(courseId).orElseThrow(() -> new EntityNotFoundException(Course.class, courseId));
         Iterable<RosterStudent> rosterStudents = rosterStudentRepository.findByCourseId(courseId);
         return rosterStudents;
+    }
+
+    /**
+     * This method updates a student from a list of roster students.
+     * 
+     * @param id       id of the student object
+     * @param incoming the new student
+     * @return the updated student object.
+     */
+    @Operation(summary= "Update a roster student")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("/updateStudent")
+    public RosterStudent updateRosterStudent(
+            @Parameter(name="id") @RequestParam Long id,
+            @RequestBody @Valid RosterStudentUpdateDTO incoming) {
+
+        RosterStudent rosterStudent = rosterStudentRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(RosterStudent.class, id));
+
+        Optional<RosterStudent> duplicate = rosterStudentRepository.findByStudentId(incoming.getStudentId());
+        if (duplicate.isPresent() && !duplicate.get().getId().equals(id)) {
+        throw new IllegalArgumentException("Another student with studentId '" 
+            + incoming.getStudentId() + "' already exists.");
+    }
+        rosterStudent.setFirstName(incoming.getFirstName());
+        rosterStudent.setLastName(incoming.getLastName());
+        rosterStudent.setStudentId(incoming.getStudentId());
+
+        rosterStudentRepository.save(rosterStudent);
+
+        return rosterStudent;
     }
 
     @Operation(summary = "Upload Roster students for Course in UCSB Egrades Format")

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
@@ -32,6 +32,7 @@ import edu.ucsb.cs156.frontiers.entities.RosterStudent;
 import edu.ucsb.cs156.frontiers.enums.OrgStatus;
 import edu.ucsb.cs156.frontiers.enums.RosterStatus;
 import edu.ucsb.cs156.frontiers.errors.EntityNotFoundException;
+import edu.ucsb.cs156.frontiers.errors.InvalidRequestException;
 import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
 import edu.ucsb.cs156.frontiers.repositories.RosterStudentRepository;
 import edu.ucsb.cs156.frontiers.dto.RosterStudentUpdateDTO;
@@ -142,9 +143,8 @@ public class RosterStudentsController extends ApiController {
 
         Optional<RosterStudent> duplicate = rosterStudentRepository.findByStudentId(incoming.getStudentId());
         if (duplicate.isPresent() && !duplicate.get().getId().equals(id)) {
-        throw new IllegalArgumentException("Another student with studentId '" 
-            + incoming.getStudentId() + "' already exists.");
-    }
+            throw new InvalidRequestException("studentId " + incoming.getStudentId() + " already exists");
+        }
         rosterStudent.setFirstName(incoming.getFirstName());
         rosterStudent.setLastName(incoming.getLastName());
         rosterStudent.setStudentId(incoming.getStudentId());

--- a/src/main/java/edu/ucsb/cs156/frontiers/dtos/RosterStudentUpdateDTO.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/dtos/RosterStudentUpdateDTO.java
@@ -1,0 +1,39 @@
+package edu.ucsb.cs156.frontiers.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class RosterStudentUpdateDTO {
+
+    @NotBlank
+    private String studentId;
+
+    @NotBlank
+    private String firstName;
+
+    @NotBlank
+    private String lastName;
+
+    public String getStudentId() {
+        return studentId;
+    }
+
+    public void setStudentId(String studentId) {
+        this.studentId = studentId;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/frontiers/errors/InvalidRequestException.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/errors/InvalidRequestException.java
@@ -1,0 +1,14 @@
+package edu.ucsb.cs156.frontiers.errors;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Custom exception for HTTP 400 Bad Request
+ */
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class InvalidRequestException extends RuntimeException {
+  public InvalidRequestException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/frontiers/repositories/RosterStudentRepository.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/repositories/RosterStudentRepository.java
@@ -14,6 +14,7 @@ public interface RosterStudentRepository extends JpaRepository<RosterStudent, Lo
 {
     List<RosterStudent> findAllByEmail(String email);
     public Iterable<RosterStudent> findByCourseId(Long courseId);
+    public Optional<RosterStudent> findByStudentId(String studentID);
     public Optional<RosterStudent> findByCourseIdAndStudentId(Long courseId, String studentId);
 
     Optional<RosterStudent> findByCourseAndGithubId(Course course, int githubId);


### PR DESCRIPTION
Closes #16 

In this PR, we add PUT (update) operations for the RosterStudent controller so that we can edit existing Roster Students.

Added a DTO folder that contains a simplified RequestBody for the Update method that only asks for the updatable variables (StudentId, StudentFirstName, and StudentLastName).

Added custom exception handle for bad update requests.

# To Test
Login to this dokku instance: https://frontiers-dev-trocha1.dokku-11.cs.ucsb.edu/

# Screenshots
<img width="1400" alt="image" src="https://github.com/user-attachments/assets/c524a1ea-ac19-46cb-913d-37fb1da8d7e4" />

Response Body
<img width="1388" alt="image" src="https://github.com/user-attachments/assets/4006d05b-7049-407e-b5fe-0098b71de9be" />


Prevents changing a studentId to one that already exists
<img width="1276" alt="image" src="https://github.com/user-attachments/assets/d535112f-5efe-423d-a86b-102b1ac0c9db" />
<img width="1273" alt="image" src="https://github.com/user-attachments/assets/1c19befb-5a16-474b-90f9-16c4d7c68e98" />
