### PR TITLE
ws - added instructor table files

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/entities/Instructor.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/entities/Instructor.java
@@ -1,0 +1,17 @@
+package edu.ucsb.cs156.frontiers.entities;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+@Table(name = "instructors")
+public class Instructor {
+
+    @Id
+    private String email;
+
+}

--- a/src/main/java/edu/ucsb/cs156/frontiers/repositories/InstructorRepository.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/repositories/InstructorRepository.java
@@ -1,0 +1,9 @@
+package edu.ucsb.cs156.frontiers.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import edu.ucsb.cs156.frontiers.entities.Instructor;
+
+public interface InstructorRepository extends JpaRepository<Instructor,String>
+{
+}

--- a/src/main/resources/db/migration/changes/008-Instructors-create.json
+++ b/src/main/resources/db/migration/changes/008-Instructors-create.json
@@ -2,8 +2,8 @@
   "databaseChangeLog": [
     {
       "changeSet": {
-        "id": "Instructor-1",
-        "author": "wsong",
+        "id": "008-Instructors-create",
+        "author": "Wendy192837",
         "preConditions": [
           { "onFail": "MARK_RAN" },
           {

--- a/src/main/resources/db/migration/changes/008-Instructors-create.json
+++ b/src/main/resources/db/migration/changes/008-Instructors-create.json
@@ -1,0 +1,38 @@
+{
+  "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "Instructor-1",
+        "author": "wsong",
+        "preConditions": [
+          { "onFail": "MARK_RAN" },
+          {
+            "not": [
+              { "tableExists": { "tableName": "INSTRUCTORS" } }
+            ]
+          }
+        ],
+        "changes": [
+          {
+            "createTable": {
+              "tableName": "INSTRUCTORS",
+              "columns": [
+                {
+                  "column": {
+                    "name": "EMAIL",
+                    "type": "VARCHAR(255)",
+                    "constraints": {
+                      "primaryKey": true,
+                      "primaryKeyName": "INSTRUCTORS_PK",
+                      "nullable": false
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
closes #11 

added files `Instructor.java`, `InstructorRepository.java`, and `008-Instructors-create.json`, which creates an Instructor entity with one attribute (email).
deployed on dokku: https://frontiers-dev-wendy192837.dokku-11.cs.ucsb.edu/
postgres connect:
<img width="603" alt="Screenshot 2025-05-16 at 13 04 59" src="https://github.com/user-attachments/assets/d6f1ef8a-db47-4e6a-a0f9-03c453046e7e" />
