### PR TITLE
js - added backend method for students to see courses they appear on roster of and status

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/CoursesController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/CoursesController.java
@@ -188,6 +188,7 @@ public class CoursesController extends ApiController {
 
             matchedCourses.add(courseInfo);
         }
+        
         return matchedCourses;
     }
 }

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/CoursesController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/CoursesController.java
@@ -2,6 +2,8 @@ package edu.ucsb.cs156.frontiers.controllers;
 
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -21,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 import edu.ucsb.cs156.frontiers.entities.Course;
+import edu.ucsb.cs156.frontiers.entities.RosterStudent;
 import edu.ucsb.cs156.frontiers.errors.EntityNotFoundException;
 import edu.ucsb.cs156.frontiers.errors.InvalidInstallationTypeException;
 import edu.ucsb.cs156.frontiers.models.CurrentUser;
@@ -30,6 +33,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
+
+import java.util.*; 
 
 @Tag(name = "Course")
 @RequestMapping("/api/courses")
@@ -154,5 +159,114 @@ public class CoursesController extends ApiController {
         );
     }
 
+    @Operation(summary = "Student can see what courses they appear on roster of and their status in each")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/lookup")
+    public List<Map<String, Object>> lookUpStudentCourseRoster() 
+    {
+        CurrentUser currentUser = getCurrentUser();
+        String studentEmail = currentUser.getUser().getEmail();
+
+        Iterable<Course> allCourses = courseRepository.findAll();
+        List<Map<String, Object>> matchedCourses = new ArrayList<>();
+
+        for (Course course : allCourses) 
+        {
+            for (RosterStudent rs : course.getRosterStudents()) 
+            {
+                if (rs.getEmail().equals(studentEmail)) 
+                {
+                    Map<String, Object> courseInfo = new HashMap<>();
+                    courseInfo.put("id", course.getId());
+                    courseInfo.put("orgName", course.getOrgName());
+                    courseInfo.put("courseName", course.getCourseName());
+                    courseInfo.put("term", course.getTerm());
+                    courseInfo.put("school", course.getSchool());
+
+                    // String installation_id = course.getInstallationId(); 
+                    // if(installation_id == null)
+                    // {
+                    //     installation_id = "setup in progress"; 
+                    // }
+                    // else 
+                    // {
+                    //     installation_id = "joinable"; 
+                    // }
+                    courseInfo.put("installationId", course.getInstallationId());
+
+                    // String status = ""; 
+                    // if (rs.getOrgStatus() != null)
+                    // {
+                    //     status = rs.getOrgStatus().name(); 
+                    //     if (status.equals("NONE"))
+                    //     {
+                    //         status = "Not yet requested"; 
+                    //     }
+                    // } 
+                    courseInfo.put("status", rs.getOrgStatus().name()); 
+
+                    matchedCourses.add(courseInfo);
+                    break; 
+                }
+            }
+        }
+
+        return matchedCourses;
+    }
+
+    // @Operation(summary = "Student can see what courses they appear on roster of and their status in each")
+    // @PreAuthorize("hasRole('ROLE_USER')")
+    // @GetMapping("/lookup")
+    // public List<Map<String, Object>> lookUpStaffCourseRoster() 
+    // {
+    //     CurrentUser currentUser = getCurrentUser();
+    //     String studentEmail = currentUser.getUser().getEmail();
+
+    //     Iterable<Course> allCourses = courseRepository.findAll();
+    //     List<Map<String, Object>> matchedCourses = new ArrayList<>();
+
+    //     for (Course course : allCourses) 
+    //     {
+    //         for (RosterStudent rs : course.getRosterStudents()) 
+    //         {
+    //             if (rs.getEmail().equals(studentEmail)) 
+    //             {
+    //                 Map<String, Object> courseInfo = new HashMap<>();
+    //                 courseInfo.put("id", course.getId());
+    //                 courseInfo.put("orgName", course.getOrgName());
+    //                 courseInfo.put("courseName", course.getCourseName());
+    //                 courseInfo.put("term", course.getTerm());
+    //                 courseInfo.put("school", course.getSchool());
+
+    //                 String installation_id = course.getInstallationId(); 
+    //                 if(installation_id == null)
+    //                 {
+    //                     installation_id = "setup in progress"; 
+    //                 }
+    //                 else 
+    //                 {
+    //                     installation_id = "joinable"; 
+    //                 }
+    //                 courseInfo.put("installationId", installation_id);
+
+    //                 String status = ""; 
+    //                 if (rs.getOrgStatus() != null)
+    //                 {
+    //                     status = rs.getOrgStatus().name(); 
+    //                     if (status.equals("NONE"))
+    //                     {
+    //                         status = "Not yet requested"; 
+    //                     }
+    //                 } 
+    //                 courseInfo.put("status", status); 
+
+    //                 matchedCourses.add(courseInfo);
+    //                 break; 
+    //             }
+    //         }
+    //     }
+
+    //     return matchedCourses;
+    // }
 
 }

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/CoursesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/CoursesControllerTests.java
@@ -13,9 +13,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.Map;
-import java.util.Optional;
-
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
@@ -34,6 +31,11 @@ import edu.ucsb.cs156.frontiers.services.CurrentUserService;
 import edu.ucsb.cs156.frontiers.services.OrganizationLinkerService;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.*; 
+import edu.ucsb.cs156.frontiers.models.CurrentUser; 
+import edu.ucsb.cs156.frontiers.entities.RosterStudent; 
+import edu.ucsb.cs156.frontiers.enums.*; 
+
 @Slf4j
 @WebMvcTest(controllers = CoursesController.class)
 @AutoConfigureDataJpa
@@ -42,7 +44,7 @@ public class CoursesControllerTests extends ControllerTestCase {
     @MockitoBean
     private CourseRepository courseRepository;
 
-    @Autowired
+    @MockitoBean
     private CurrentUserService currentUserService;
 
     @MockitoBean
@@ -55,8 +57,13 @@ public class CoursesControllerTests extends ControllerTestCase {
     @WithMockUser(roles = { "ADMIN" })
     public void testPostCourse() throws Exception {
 
-        User user = currentUserService.getCurrentUser().getUser();
-
+        User user = User.builder()
+                .email("cgaucho@example.org")
+                .build();
+        CurrentUser cUser = CurrentUser.builder()
+                .user(user)
+                .build(); 
+        when(currentUserService.getCurrentUser()).thenReturn(cUser); 
 
         // arrange
         Course course = Course.builder()
@@ -148,7 +155,14 @@ public class CoursesControllerTests extends ControllerTestCase {
     @Test
     @WithMockUser(roles = {"ADMIN"})
     public void testLinkCourseSuccessfully() throws Exception {
-        User user = currentUserService.getCurrentUser().getUser();
+        User user = User.builder()
+                .email("cgaucho@example.org")
+                .build();
+        CurrentUser cUser = CurrentUser.builder()
+                .user(user)
+                .build(); 
+        when(currentUserService.getCurrentUser()).thenReturn(cUser); 
+
         Course course1 = Course.builder()
                 .courseName("CS156")
                 .term("S25")
@@ -200,6 +214,14 @@ public class CoursesControllerTests extends ControllerTestCase {
     @Test
     @WithMockUser(roles = {"ADMIN"})
     public void testNotCreator() throws Exception {
+        User user = User.builder()
+                .email("cgaucho@example.org")
+                .build();
+        CurrentUser cUser = CurrentUser.builder()
+                .user(user)
+                .build(); 
+        when(currentUserService.getCurrentUser()).thenReturn(cUser); 
+
         User separateUser = User.builder().id(2L).build();
         Course course1 = Course.builder()
                 .courseName("CS156")
@@ -243,7 +265,14 @@ public class CoursesControllerTests extends ControllerTestCase {
     @Test
     @WithMockUser(roles = {"ADMIN"})
     public void testNotOrganization() throws Exception {
-        User user = currentUserService.getCurrentUser().getUser();
+        User user = User.builder()
+                .email("cgaucho@example.org")
+                .build();
+        CurrentUser cUser = CurrentUser.builder()
+                .user(user)
+                .build(); 
+        when(currentUserService.getCurrentUser()).thenReturn(cUser); 
+
         Course course1 = Course.builder()
                 .courseName("CS156")
                 .term("S25")
@@ -269,4 +298,82 @@ public class CoursesControllerTests extends ControllerTestCase {
         String expectedJson = mapper.writeValueAsString(expectedMap);
         assertEquals(expectedJson, responseString);
     }
+
+    @Test
+    @WithMockUser(roles = { "USER" })
+    public void testLookUpStudentCourseRoster() throws Exception {
+
+        User user = User.builder()
+                .email("cgaucho@example.org")
+                .build();
+        CurrentUser cUser = CurrentUser.builder()
+                .user(user)
+                .build(); 
+        when(currentUserService.getCurrentUser()).thenReturn(cUser); 
+
+        Course course = Course.builder()
+                .id(1L)
+                .courseName("CS156")
+                .orgName("ucsb-cs156")
+                .installationId(null)
+                .term("F23")
+                .school("Engineering")
+                .build();
+
+        Course course2 = Course.builder()
+                .id(2L)
+                .courseName("CS157")
+                .orgName("ucsb-cs157")
+                .installationId("1234")
+                .term("F23")
+                .school("Engineering")
+                .build();
+
+        RosterStudent rs1 = RosterStudent.builder()
+                        .user(user)
+                        .email("cgaucho@example.org")
+                        .course(course)
+                        .rosterStatus(RosterStatus.MANUAL)
+                        .orgStatus(OrgStatus.NONE)
+                        .build();
+
+        RosterStudent rs2 = RosterStudent.builder()
+                        .email("test@example.org")
+                        .course(course)
+                        .rosterStatus(RosterStatus.MANUAL)
+                        .orgStatus(OrgStatus.NONE)
+                        .build();
+
+        course.setRosterStudents(List.of(rs1, rs2));
+        course2.setRosterStudents(List.of(rs1));
+
+        when(courseRepository.findAll()).thenReturn(List.of(course, course2));
+
+        MvcResult response = mockMvc.perform(get("/api/courses/lookup"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String responseString = response.getResponse().getContentAsString();
+        Map<String, Object> expectedMap = new HashMap<>();
+        expectedMap.put("id", course.getId());
+        expectedMap.put("orgName", course.getOrgName());
+        expectedMap.put("courseName", course.getCourseName());
+        expectedMap.put("term", course.getTerm());
+        expectedMap.put("school", course.getSchool());
+        expectedMap.put("installationId", course.getInstallationId()); 
+        expectedMap.put("status", "NONE"); 
+
+        Map<String, Object> expectedMap2 = new HashMap<>();
+        expectedMap2.put("id", course2.getId());
+        expectedMap2.put("orgName", course2.getOrgName());
+        expectedMap2.put("courseName", course2.getCourseName());
+        expectedMap2.put("term", course2.getTerm());
+        expectedMap2.put("school", course2.getSchool());
+        expectedMap2.put("installationId", course2.getInstallationId()); 
+        expectedMap2.put("status", "NONE"); 
+
+        String expectedJson = mapper.writeValueAsString(List.of(expectedMap, expectedMap2));
+        assertEquals(expectedJson, responseString);
+    }
+
 }

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/CoursesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/CoursesControllerTests.java
@@ -340,13 +340,6 @@ public class CoursesControllerTests extends ControllerTestCase {
                 .rosterStatus(RosterStatus.MANUAL)
                 .orgStatus(OrgStatus.NONE)
                 .build();
-
-        RosterStudent rs2 = RosterStudent.builder()
-                .email("test@example.org")
-                .course(course)
-                .rosterStatus(RosterStatus.MANUAL)
-                .orgStatus(OrgStatus.NONE)
-                .build();
         
         when(courseRepository.findAll()).thenReturn(List.of(course, course2));
         when(rosterStudentRepository.findAllByEmail("cgaucho@example.org")).thenReturn(List.of(rs1));


### PR DESCRIPTION
Closes #10 

Added method for students to see courses they appear on roster of and the status of the corresponding organization. 
The method returns the course fields: id, installationId, orgName, courseName, term, school
Test this on: https://frontiers-dev-jonahso.dokku-11.cs.ucsb.edu/ 

1) Create a course 
![image](https://github.com/user-attachments/assets/f97bb1ef-1ca0-4faf-be4f-8694f326ae59)

2) Link the course to a roster student (use the email that you logged in) 
![image](https://github.com/user-attachments/assets/af609d72-2510-46bf-8557-746917aff802)

3) See the course info associated with the current user: 
![image](https://github.com/user-attachments/assets/8c6145f2-99ba-460d-865b-90883634dc55)
![image](https://github.com/user-attachments/assets/0d658c9e-8377-490f-a92e-744c4b395f0c)
