### PR TITLE
sd - Admin DELETE operation implemented 

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/AdminsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/AdminsController.java
@@ -28,7 +28,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 
 public class AdminsController extends ApiController{
-
     @Autowired
     AdminRepository adminRepository;
 

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/AdminsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/AdminsController.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.frontiers.controllers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import edu.ucsb.cs156.frontiers.errors.EntityNotFoundException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import edu.ucsb.cs156.frontiers.entities.Admin;
@@ -9,6 +10,7 @@ import edu.ucsb.cs156.frontiers.repositories.AdminRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -60,5 +62,22 @@ public class AdminsController extends ApiController{
     public Iterable<Admin> allAdmins() {
         Iterable<Admin> admins = adminRepository.findAll();
         return admins;
+    }
+
+    /**
+     * Delete an admin. Accessible only to users with the role "ROLE_ADMIN".
+     * @param email email of the admin
+     * @return a message indiciating the organization was deleted
+     */
+    @Operation(summary= "Delete an Admin")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteAdmin(
+            @Parameter(name="email") @RequestParam String email) {
+        Admin admin = adminRepository.findById(email)
+                .orElseThrow(() -> new EntityNotFoundException(Admin.class, email));
+
+        adminRepository.delete(admin);
+        return genericMessage("Admin with id %s deleted".formatted(email));
     }
 }

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/AdminsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/AdminsController.java
@@ -16,11 +16,16 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.beans.factory.annotation.Value;
+
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+
 
 @Tag(name = "Admins")
 @RequestMapping("/api/admins")
@@ -63,6 +68,9 @@ public class AdminsController extends ApiController{
         return admins;
     }
 
+    @Value("#{'${app.admin.emails}'.split(',')}")
+    private List<String> adminEmails;
+
     /**
      * Delete an admin. Accessible only to users with the role "ROLE_ADMIN".
      * @param email email of the admin
@@ -75,6 +83,10 @@ public class AdminsController extends ApiController{
             @Parameter(name="email") @RequestParam String email) {
         Admin admin = adminRepository.findById(email)
                 .orElseThrow(() -> new EntityNotFoundException(Admin.class, email));
+
+        if (adminEmails.contains(email)) {
+        throw new UnsupportedOperationException("Can not delete an admin from ADMIN_EMAILS list");
+        }
 
         adminRepository.delete(admin);
         return genericMessage("Admin with id %s deleted".formatted(email));

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/ApiController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/ApiController.java
@@ -7,12 +7,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.http.ResponseEntity;
 
 import edu.ucsb.cs156.frontiers.errors.EntityNotFoundException;
 import edu.ucsb.cs156.frontiers.models.CurrentUser;
 import edu.ucsb.cs156.frontiers.services.CurrentUserService;
 
 import java.util.Map;
+
 
 /**
  * This is an abstract class that provides common functionality for all API controllers.
@@ -66,5 +68,16 @@ public abstract class ApiController {
             "type", e.getClass().getSimpleName(),
             "message", e.getMessage()
     );
+  }
+
+  /**
+   * This method handles the UnsupportedOperationException.
+   * @param e the exception
+   * @return a map with the message of the exception
+   */
+  @ExceptionHandler(UnsupportedOperationException.class)
+  public ResponseEntity<Map<String, String>> handleUnsupportedOperation(UnsupportedOperationException e) {
+      return ResponseEntity.status(HttpStatus.FORBIDDEN)
+              .body(Map.of("message", e.getMessage()));
   }
 }


### PR DESCRIPTION
Closes #5 

In this PR, the DELETE operation and its tests are implemented for the Admin table. Now it throws a 403 error code if you try deleting an admin that is found in admin_emails.

You can test it here: https://frontiers-dev-sauld04.dokku-11.cs.ucsb.edu/
![image](https://github.com/user-attachments/assets/c6851642-cb4f-4df1-bf7e-6aa4f4f5e34c)

![image](https://github.com/user-attachments/assets/80f2dea7-feab-4b4d-866e-119b08adbe5a)

