### PR TITLE
tr - add delete method for RosterStudent controller

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
@@ -10,41 +10,46 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import edu.ucsb.cs156.frontiers.entities.Job;
-import edu.ucsb.cs156.frontiers.entities.User;
-import edu.ucsb.cs156.frontiers.errors.NoLinkedOrganizationException;
-import edu.ucsb.cs156.frontiers.jobs.UpdateOrgMembershipJob;
-import edu.ucsb.cs156.frontiers.repositories.UserRepository;
-import edu.ucsb.cs156.frontiers.services.*;
-import edu.ucsb.cs156.frontiers.services.jobs.JobService;
-import org.apache.coyote.BadRequestException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.opencsv.CSVReader;
+import com.opencsv.exceptions.CsvException;
 
+import edu.ucsb.cs156.frontiers.dtos.RosterStudentUpdateDTO;
 import edu.ucsb.cs156.frontiers.entities.Course;
+import edu.ucsb.cs156.frontiers.entities.Job;
 import edu.ucsb.cs156.frontiers.entities.RosterStudent;
+import edu.ucsb.cs156.frontiers.entities.User;
 import edu.ucsb.cs156.frontiers.enums.OrgStatus;
 import edu.ucsb.cs156.frontiers.enums.RosterStatus;
 import edu.ucsb.cs156.frontiers.errors.EntityNotFoundException;
 import edu.ucsb.cs156.frontiers.errors.InvalidRequestException;
+import edu.ucsb.cs156.frontiers.errors.NoLinkedOrganizationException;
+import edu.ucsb.cs156.frontiers.jobs.UpdateOrgMembershipJob;
 import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
 import edu.ucsb.cs156.frontiers.repositories.RosterStudentRepository;
-import edu.ucsb.cs156.frontiers.dto.RosterStudentUpdateDTO;
+import edu.ucsb.cs156.frontiers.services.CurrentUserService;
+import edu.ucsb.cs156.frontiers.services.OrganizationMemberService;
+import edu.ucsb.cs156.frontiers.services.UpdateUserService;
+import edu.ucsb.cs156.frontiers.services.jobs.JobService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.extern.slf4j.Slf4j;
-
-import com.opencsv.CSVReader;
-import com.opencsv.exceptions.CsvException;
-
 import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
 
 @Tag(name = "RosterStudents")
 @RequestMapping("/api/rosterstudents")
@@ -152,6 +157,29 @@ public class RosterStudentsController extends ApiController {
         rosterStudentRepository.save(rosterStudent);
 
         return rosterStudent;
+    }
+
+    /**
+     * This method deletes a RosterStudent
+     * 
+     * @param id id of the student object
+     * @return   a message indicating the student was deleted
+     */
+    @Operation(summary= "Delete a RosterStudent")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteRosterStudent(
+            @Parameter(name="id") @RequestParam Long id) {
+
+        RosterStudent rosterStudent = rosterStudentRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(RosterStudent.class, id));
+
+        rosterStudentRepository.delete(rosterStudent);
+
+        Course course = rosterStudent.getCourse();
+        course.getRosterStudents().remove(rosterStudent); // remove from list
+        courseRepository.save(course);
+        return genericMessage("RosterStudent with id %s deleted".formatted(id));
     }
 
     @Operation(summary = "Upload Roster students for Course in UCSB Egrades Format")

--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsController.java
@@ -1,5 +1,4 @@
 package edu.ucsb.cs156.frontiers.controllers;
-
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -10,46 +9,41 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import edu.ucsb.cs156.frontiers.entities.Job;
+import edu.ucsb.cs156.frontiers.entities.User;
+import edu.ucsb.cs156.frontiers.errors.NoLinkedOrganizationException;
+import edu.ucsb.cs156.frontiers.jobs.UpdateOrgMembershipJob;
+import edu.ucsb.cs156.frontiers.repositories.UserRepository;
+import edu.ucsb.cs156.frontiers.services.*;
+import edu.ucsb.cs156.frontiers.services.jobs.JobService;
+import org.apache.coyote.BadRequestException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.opencsv.CSVReader;
-import com.opencsv.exceptions.CsvException;
 
-import edu.ucsb.cs156.frontiers.dtos.RosterStudentUpdateDTO;
 import edu.ucsb.cs156.frontiers.entities.Course;
-import edu.ucsb.cs156.frontiers.entities.Job;
 import edu.ucsb.cs156.frontiers.entities.RosterStudent;
-import edu.ucsb.cs156.frontiers.entities.User;
 import edu.ucsb.cs156.frontiers.enums.OrgStatus;
 import edu.ucsb.cs156.frontiers.enums.RosterStatus;
 import edu.ucsb.cs156.frontiers.errors.EntityNotFoundException;
 import edu.ucsb.cs156.frontiers.errors.InvalidRequestException;
-import edu.ucsb.cs156.frontiers.errors.NoLinkedOrganizationException;
-import edu.ucsb.cs156.frontiers.jobs.UpdateOrgMembershipJob;
 import edu.ucsb.cs156.frontiers.repositories.CourseRepository;
 import edu.ucsb.cs156.frontiers.repositories.RosterStudentRepository;
-import edu.ucsb.cs156.frontiers.services.CurrentUserService;
-import edu.ucsb.cs156.frontiers.services.OrganizationMemberService;
-import edu.ucsb.cs156.frontiers.services.UpdateUserService;
-import edu.ucsb.cs156.frontiers.services.jobs.JobService;
+import edu.ucsb.cs156.frontiers.dto.RosterStudentUpdateDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
+
+import com.opencsv.CSVReader;
+import com.opencsv.exceptions.CsvException;
+
+import jakarta.validation.Valid;
 
 @Tag(name = "RosterStudents")
 @RequestMapping("/api/rosterstudents")

--- a/src/main/java/edu/ucsb/cs156/frontiers/entities/Course.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/entities/Course.java
@@ -41,7 +41,7 @@ public class Course {
     @ToString.Exclude
     private List<CourseStaff> courseStaff;
 
-    @OneToMany(cascade = CascadeType.ALL, mappedBy = "course")
+    @OneToMany(cascade = CascadeType.ALL, mappedBy = "course", orphanRemoval = true)
     @Fetch(FetchMode.JOIN)
     @JsonIgnore
     @ToString.Exclude

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsControllerTests.java
@@ -978,7 +978,7 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                                 .andExpect(status().is(403)); // only admins can delete
         }
 
-        @WithMockUser(roles = { "ADMIN", "USER" })
+        @WithMockUser(roles = { "ADMIN" })
         @Test
         public void admin_can_delete_a_rosterstudent() throws Exception {
                 // arrange
@@ -1025,7 +1025,7 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                 "RosterStudent should be removed from course1's roster list");
         }
 
-        @WithMockUser(roles = { "ADMIN", "USER" })
+        @WithMockUser(roles = { "ADMIN" })
         @Test
         public void admin_tries_to_delete_non_existant_rosterstudent_and_gets_right_error_message()
                         throws Exception {

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/RosterStudentsControllerTests.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -1003,6 +1004,8 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
                         .user(currentUser)
                         .build();
 
+                course1.getRosterStudents().add(rosterStudent);
+
                 when(rosterStudentRepository.findById(eq(15L))).thenReturn(Optional.of(rosterStudent));
 
                 // act
@@ -1017,6 +1020,9 @@ public class RosterStudentsControllerTests extends ControllerTestCase {
 
                 Map<String, Object> json = responseToJson(response);
                 assertEquals("RosterStudent with id 15 deleted", json.get("message"));
+
+                assertFalse(course1.getRosterStudents().contains(rosterStudent),
+                "RosterStudent should be removed from course1's roster list");
         }
 
         @WithMockUser(roles = { "ADMIN", "USER" })


### PR DESCRIPTION
Closes #17 

In this PR, we add the delete operation for the RosterStudent controller.

Deleting a roster student also removes them from their assigned course's list of roster students.

# To Test
Login to this dokku instance: https://frontiers-dev-trocha1.dokku-11.cs.ucsb.edu/

# Screenshots
<img width="1412" alt="image" src="https://github.com/user-attachments/assets/6234eb84-59cb-4980-bcb8-b106edac0b5a" />

### When a student is already deleted or does not exist:
<img width="1411" alt="image" src="https://github.com/user-attachments/assets/ccb6505d-f7ae-4a29-b17c-bb59f26f7a38" />