### PR TITLE
tr - added startup code to populate Admins table from ADMIN_EMAILS

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/repositories/AdminRepository.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/repositories/AdminRepository.java
@@ -6,4 +6,5 @@ import edu.ucsb.cs156.frontiers.entities.Admin;
 
 @Repository
 public interface AdminRepository extends JpaRepository<Admin, String> {
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/edu/ucsb/cs156/frontiers/startup/FrontiersApplicationRunner.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/startup/FrontiersApplicationRunner.java
@@ -1,0 +1,23 @@
+package edu.ucsb.cs156.frontiers.startup;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+/** This class contains a `run` method that is called once at application startup time. */
+@Slf4j
+@Configuration
+public class FrontiersApplicationRunner implements ApplicationRunner {
+
+  @Autowired FrontiersStartup frontiersStartup;
+
+  /** Called once at application startup time */
+  @Override
+  public void run(ApplicationArguments args) throws Exception {
+    log.info("FrontiersApplicationRunnerDevelopment.run called");
+    frontiersStartup.alwaysRunOnStartup();
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/frontiers/startup/FrontiersStartup.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/startup/FrontiersStartup.java
@@ -1,0 +1,43 @@
+package edu.ucsb.cs156.frontiers.startup;
+
+import edu.ucsb.cs156.frontiers.entities.Admin;
+import edu.ucsb.cs156.frontiers.repositories.AdminRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/** This class contains a `run` method that is called once at application startup time. */
+@Slf4j
+@Component
+public class FrontiersStartup {
+
+    private final AdminRepository adminRepository;
+
+    @Value("${app.admin.emails}")
+    private List<String> adminEmails;
+
+    public FrontiersStartup(AdminRepository adminRepository) {
+        this.adminRepository = adminRepository;
+    }
+
+    /**
+    * Called once at application startup time . Put code here if you want it to run once each time
+    * the Spring Boot application starts up in all environments.
+    */
+    public void alwaysRunOnStartup() {
+        log.info("Running FrontiersStartup.alwaysRunOnStartup");
+
+        for (String email : adminEmails) {
+            if (!adminRepository.existsByEmail(email)) {
+                Admin admin = Admin.builder().email(email).build();
+                adminRepository.save(admin);
+                log.info("Added admin: {}", email);
+            } else {
+                log.info("Admin already exists: {}", email);
+            }
+        }
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/frontiers/startup/FrontiersApplicationRunnerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/startup/FrontiersApplicationRunnerTests.java
@@ -1,0 +1,32 @@
+package edu.ucsb.cs156.frontiers.startup;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.ApplicationArguments;
+
+import static org.mockito.Mockito.*;
+
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest
+public class FrontiersApplicationRunnerTests {
+
+    @Autowired
+    private FrontiersApplicationRunner runner;
+
+    @MockBean
+    private FrontiersStartup frontiersStartup;
+
+    @Test
+    public void test_run_calls_frontiersStartup() throws Exception {
+        ApplicationArguments mockArgs = mock(ApplicationArguments.class);
+
+        // Clear any invocations that happened during startup
+        clearInvocations(frontiersStartup);
+
+        runner.run(mockArgs);
+
+        verify(frontiersStartup, times(1)).alwaysRunOnStartup();
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/frontiers/startup/FrontiersStartupTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/startup/FrontiersStartupTests.java
@@ -1,0 +1,74 @@
+package edu.ucsb.cs156.frontiers.startup;
+
+import edu.ucsb.cs156.frontiers.entities.Admin;
+import edu.ucsb.cs156.frontiers.repositories.AdminRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class FrontiersStartupTests {
+
+    private AdminRepository adminRepository;
+    private FrontiersStartup frontiersStartup;
+
+    @BeforeEach
+    public void setUp() {
+        adminRepository = mock(AdminRepository.class);
+        frontiersStartup = new FrontiersStartup(adminRepository);
+    }
+
+    @Test
+    public void testAlwaysRunOnStartup_addsAllEmails() {
+        // Arrange
+
+        List<String> testEmails = List.of("admin1@example.com", "admin2@example.com");
+        ReflectionTestUtils.setField(frontiersStartup, "adminEmails", testEmails);
+
+        when(adminRepository.existsByEmail(anyString())).thenReturn(false);
+
+        // Act 
+
+        frontiersStartup.alwaysRunOnStartup();
+
+        // Assert
+
+        ArgumentCaptor<Admin> captor = ArgumentCaptor.forClass(Admin.class);
+        verify(adminRepository, times(2)).save(captor.capture());
+
+        List<Admin> savedAdmins = captor.getAllValues();
+        assertEquals(2, savedAdmins.size());
+        assertTrue(savedAdmins.stream().anyMatch(a -> a.getEmail().equals("admin1@example.com")));
+        assertTrue(savedAdmins.stream().anyMatch(a -> a.getEmail().equals("admin2@example.com")));
+    }
+
+    @Test
+    public void test_alwaysRunOnStartup_skips_existing_admins() {
+        // Arrange
+
+        List<String> testEmails = List.of("existing@example.com", "new@example.com");
+        ReflectionTestUtils.setField(frontiersStartup, "adminEmails", testEmails);
+
+        when(adminRepository.existsByEmail("existing@example.com")).thenReturn(true);
+        when(adminRepository.existsByEmail("new@example.com")).thenReturn(false);
+
+        // Act
+
+        frontiersStartup.alwaysRunOnStartup();
+
+        // Assert 
+
+        ArgumentCaptor<Admin> adminCaptor = ArgumentCaptor.forClass(Admin.class);
+        verify(adminRepository, times(1)).save(adminCaptor.capture());
+        Admin savedAdmin = adminCaptor.getValue();
+        assertEquals("new@example.com", savedAdmin.getEmail());
+
+        verify(adminRepository, times(1)).existsByEmail("existing@example.com");
+        verify(adminRepository, times(1)).existsByEmail("new@example.com");
+    }
+}


### PR DESCRIPTION
Closes #1 

In this PR, we implement FrontiersApplicationRunner and FrontiersStartup to seed Admin emails at startup.

# To Test
Login to this dokku instance: https://frontiers-qa.dokku-11.cs.ucsb.edu/

# Screenshots
<img width="1411" alt="image" src="https://github.com/user-attachments/assets/c7c3f5cf-9571-45f2-b40e-096725e7f30c" />

<img width="1411" alt="image" src="https://github.com/user-attachments/assets/73e4b95a-185c-43a0-887b-dd893b7b6ff5" />