### PR TITLE
sl - add table component for RosterStudents(storybook only)

### DIFF
--- a/frontend/src/fixtures/RosterStudentsFixtures.js
+++ b/frontend/src/fixtures/RosterStudentsFixtures.js
@@ -1,0 +1,49 @@
+import coursesFixtures from "./coursesFixtures";
+import usersFixtures from "./usersFixtures";
+
+const RosterStudentsFixtures = {
+    threeRosterStudents: [
+      {
+        id: 1,
+        course: coursesFixtures.threeCourses[0],
+        studentId: "9627X84",
+        firstName: "Shuang",
+        lastName: "Li",
+        email: "shuang@ucsb.edu",
+        user: usersFixtures.threeUsers[0],
+        rosterStatus: "ENROLLED",
+        orgStatus: "INVITED",
+        githubId: 123456,
+        githubLogin: "aliceGH",
+      },
+      {
+        id: 2,
+        course: coursesFixtures.threeCourses[0],
+        studentId: "5888Y89",
+        firstName: "Andrew",
+        lastName: "Green",
+        email: "andrew@ucsb.edu",
+        user: usersFixtures.threeUsers[1],
+        rosterStatus: "DROPPED",
+        orgStatus: "NONE",
+        githubId: 537424,
+        githubLogin: "bobGH",
+      },
+      {
+        id: 3,
+        course: coursesFixtures.threeCourses[1],
+        studentId: "6666P11",
+        firstName: "Wendy",
+        lastName: "Song",
+        email: "wendy@ucsb.edu",
+        user: usersFixtures.threeUsers[2],
+        rosterStatus: "ROSTER",
+        orgStatus: "MEMBER",
+        githubId: null,
+        githubLogin: null,
+      },
+    ],
+  };
+  
+  export default RosterStudentsFixtures;
+  

--- a/frontend/src/fixtures/RosterStudentsFixtures.js
+++ b/frontend/src/fixtures/RosterStudentsFixtures.js
@@ -2,48 +2,47 @@ import coursesFixtures from "./coursesFixtures";
 import usersFixtures from "./usersFixtures";
 
 const RosterStudentsFixtures = {
-    threeRosterStudents: [
-      {
-        id: 1,
-        course: coursesFixtures.threeCourses[0],
-        studentId: "9627X84",
-        firstName: "Shuang",
-        lastName: "Li",
-        email: "shuang@ucsb.edu",
-        user: usersFixtures.threeUsers[0],
-        rosterStatus: "ENROLLED",
-        orgStatus: "INVITED",
-        githubId: 123456,
-        githubLogin: "aliceGH",
-      },
-      {
-        id: 2,
-        course: coursesFixtures.threeCourses[0],
-        studentId: "5888Y89",
-        firstName: "Andrew",
-        lastName: "Green",
-        email: "andrew@ucsb.edu",
-        user: usersFixtures.threeUsers[1],
-        rosterStatus: "DROPPED",
-        orgStatus: "NONE",
-        githubId: 537424,
-        githubLogin: "bobGH",
-      },
-      {
-        id: 3,
-        course: coursesFixtures.threeCourses[1],
-        studentId: "6666P11",
-        firstName: "Wendy",
-        lastName: "Song",
-        email: "wendy@ucsb.edu",
-        user: usersFixtures.threeUsers[2],
-        rosterStatus: "ROSTER",
-        orgStatus: "MEMBER",
-        githubId: null,
-        githubLogin: null,
-      },
-    ],
-  };
-  
-  export default RosterStudentsFixtures;
-  
+  threeRosterStudents: [
+    {
+      id: 1,
+      course: coursesFixtures.threeCourses[0],
+      studentId: "9627X84",
+      firstName: "Shuang",
+      lastName: "Li",
+      email: "shuang@ucsb.edu",
+      user: usersFixtures.threeUsers[0],
+      rosterStatus: "ENROLLED",
+      orgStatus: "INVITED",
+      githubId: 123456,
+      githubLogin: "aliceGH",
+    },
+    {
+      id: 2,
+      course: coursesFixtures.threeCourses[0],
+      studentId: "5888Y89",
+      firstName: "Andrew",
+      lastName: "Green",
+      email: "andrew@ucsb.edu",
+      user: usersFixtures.threeUsers[1],
+      rosterStatus: "DROPPED",
+      orgStatus: "NONE",
+      githubId: 537424,
+      githubLogin: "bobGH",
+    },
+    {
+      id: 3,
+      course: coursesFixtures.threeCourses[1],
+      studentId: "6666P11",
+      firstName: "Wendy",
+      lastName: "Song",
+      email: "wendy@ucsb.edu",
+      user: usersFixtures.threeUsers[2],
+      rosterStatus: "ROSTER",
+      orgStatus: "MEMBER",
+      githubId: null,
+      githubLogin: null,
+    },
+  ],
+};
+
+export default RosterStudentsFixtures;

--- a/frontend/src/fixtures/rosterStudentsFixtures.js
+++ b/frontend/src/fixtures/rosterStudentsFixtures.js
@@ -1,7 +1,7 @@
 import coursesFixtures from "./coursesFixtures";
 import usersFixtures from "./usersFixtures";
 
-const RosterStudentsFixtures = {
+const rosterStudentsFixtures = {
   threeRosterStudents: [
     {
       id: 1,
@@ -45,4 +45,4 @@ const RosterStudentsFixtures = {
   ],
 };
 
-export default RosterStudentsFixtures;
+export default rosterStudentsFixtures;

--- a/frontend/src/main/components/RosterStudents/RosterStudentsTable.js
+++ b/frontend/src/main/components/RosterStudents/RosterStudentsTable.js
@@ -1,0 +1,71 @@
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+
+const columns = [
+  {
+    Header: "id",
+    accessor: "id", // accessor is the "key" in the data
+  },
+  {
+    Header: "First Name",
+    accessor: "firstName",
+  },
+  {
+    Header: "Last Name",
+    accessor: "lastName",
+  },
+  {
+    Header: "Email",
+    accessor: "email",
+  },
+  {
+    Header: " GitHub Username",
+    accessor: "githubLogin",
+  },
+  {
+    Header: "GitHub ID",
+    accessor: "githubId",
+  },
+];
+
+export default function RosterStudentTable({
+  rosterStudents,
+  showButtons = false,
+  storybook = false,
+}) {
+  const editCallback = (cell) => {
+    const id = cell.row.values.id;
+    const msg = `Edit clicked for row with id: ${id}`;
+    if (storybook) {
+      window.alert(msg);
+    } else {
+      console.log(msg);
+    }
+  };
+  
+  const deleteCallback = (cell) => {
+    const id = cell.row.values.id;
+    const msg = `Delete clicked for row with id: ${id}`;
+    if (storybook) {
+      window.alert(msg);
+    } else {
+      console.log(msg);
+    }
+  };
+  
+  const columnsToDisplay = showButtons
+    ? [
+        ...columns,
+        ButtonColumn("Edit", "primary", editCallback, "RosterStudentsTable"),
+        ButtonColumn("Delete", "danger", deleteCallback, "RosterStudentsTable"),
+      ]
+    : columns;
+  
+
+  return (
+    <OurTable
+      data={rosterStudents}
+      columns={columnsToDisplay}
+      testid={"RosterStudentsTable"}
+    />
+  );
+}

--- a/frontend/src/main/components/RosterStudents/RosterStudentsTable.js
+++ b/frontend/src/main/components/RosterStudents/RosterStudentsTable.js
@@ -41,7 +41,7 @@ export default function RosterStudentTable({
       console.log(msg);
     }
   };
-  
+
   const deleteCallback = (cell) => {
     const id = cell.row.values.id;
     const msg = `Delete clicked for row with id: ${id}`;
@@ -51,7 +51,7 @@ export default function RosterStudentTable({
       console.log(msg);
     }
   };
-  
+
   const columnsToDisplay = showButtons
     ? [
         ...columns,
@@ -59,7 +59,6 @@ export default function RosterStudentTable({
         ButtonColumn("Delete", "danger", deleteCallback, "RosterStudentsTable"),
       ]
     : columns;
-  
 
   return (
     <OurTable

--- a/frontend/src/stories/components/RosterStudents/RosterStudentTable.stories.js
+++ b/frontend/src/stories/components/RosterStudents/RosterStudentTable.stories.js
@@ -2,7 +2,6 @@ import React from "react";
 import RosterStudentTable from "main/components/RosterStudents/RosterStudentsTable";
 import RosterStudentsFixtures from "fixtures/RosterStudentsFixtures";
 
-
 export default {
   title: "components/RosterStudents/RosterStudentTable",
   component: RosterStudentTable,

--- a/frontend/src/stories/components/RosterStudents/RosterStudentTable.stories.js
+++ b/frontend/src/stories/components/RosterStudents/RosterStudentTable.stories.js
@@ -1,0 +1,33 @@
+import React from "react";
+import RosterStudentTable from "main/components/RosterStudents/RosterStudentsTable";
+import RosterStudentsFixtures from "fixtures/RosterStudentsFixtures";
+
+
+export default {
+  title: "components/RosterStudents/RosterStudentTable",
+  component: RosterStudentTable,
+};
+
+const Template = (args) => <RosterStudentTable {...args} />;
+
+export const Empty = Template.bind({});
+Empty.args = {
+  rosterStudents: [],
+  showButtons: false,
+  storybook: true,
+};
+
+export const ThreeRosterStudents = Template.bind({});
+ThreeRosterStudents.args = {
+  rosterStudents: RosterStudentsFixtures.threeRosterStudents,
+  showButtons: false,
+  storybook: true,
+};
+
+export const ThreeRosterStudentsWithButtons = Template.bind({});
+ThreeRosterStudentsWithButtons.args = {
+  rosterStudents: RosterStudentsFixtures.threeRosterStudents,
+  showButtons: true,
+  storybook: true,
+};
+ThreeRosterStudentsWithButtons.parameters = {};

--- a/frontend/src/stories/components/RosterStudents/RosterStudentTable.stories.js
+++ b/frontend/src/stories/components/RosterStudents/RosterStudentTable.stories.js
@@ -1,6 +1,6 @@
 import React from "react";
 import RosterStudentTable from "main/components/RosterStudents/RosterStudentsTable";
-import RosterStudentsFixtures from "fixtures/RosterStudentsFixtures";
+import RosterStudentsFixtures from "fixtures/rosterStudentsFixtures";
 
 export default {
   title: "components/RosterStudents/RosterStudentTable",

--- a/frontend/src/stories/components/RosterStudents/RosterStudentTable.stories.js
+++ b/frontend/src/stories/components/RosterStudents/RosterStudentTable.stories.js
@@ -1,6 +1,6 @@
 import React from "react";
 import RosterStudentTable from "main/components/RosterStudents/RosterStudentsTable";
-import RosterStudentsFixtures from "fixtures/rosterStudentsFixtures";
+import rosterStudentsFixtures from "fixtures/rosterStudentsFixtures";
 
 export default {
   title: "components/RosterStudents/RosterStudentTable",
@@ -18,14 +18,14 @@ Empty.args = {
 
 export const ThreeRosterStudents = Template.bind({});
 ThreeRosterStudents.args = {
-  rosterStudents: RosterStudentsFixtures.threeRosterStudents,
+  rosterStudents: rosterStudentsFixtures.threeRosterStudents,
   showButtons: false,
   storybook: true,
 };
 
 export const ThreeRosterStudentsWithButtons = Template.bind({});
 ThreeRosterStudentsWithButtons.args = {
-  rosterStudents: RosterStudentsFixtures.threeRosterStudents,
+  rosterStudents: rosterStudentsFixtures.threeRosterStudents,
   showButtons: true,
   storybook: true,
 };

--- a/frontend/src/tests/components/RosterStudents/RosterStudentsTable.test.js
+++ b/frontend/src/tests/components/RosterStudents/RosterStudentsTable.test.js
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import RosterStudentsTable from "main/components/RosterStudents/RosterStudentsTable";
-import rosterStudentsFixtures from "fixtures/RosterStudentsFixtures";
+import rosterStudentsFixtures from "fixtures/rosterStudentsFixtures";
 import { BrowserRouter } from "react-router-dom";
 
 window.alert = jest.fn();

--- a/frontend/src/tests/components/RosterStudents/RosterStudentsTable.test.js
+++ b/frontend/src/tests/components/RosterStudents/RosterStudentsTable.test.js
@@ -1,0 +1,157 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import RosterStudentsTable from "main/components/RosterStudents/RosterStudentsTable";
+import rosterStudentsFixtures from "fixtures/RosterStudentsFixtures";
+import { BrowserRouter } from "react-router-dom";
+
+window.alert = jest.fn();
+
+describe("RosterStudentsTable tests", () => {
+  const testId = "RosterStudentsTable";
+
+  test("renders correct column headers", () => {
+    const expectedHeaders = [
+      "id",
+      "First Name",
+      "Last Name",
+      "Email",
+      "GitHub Username",
+      "GitHub ID",
+    ];
+
+    render(
+      <BrowserRouter>
+        <RosterStudentsTable rosterStudents={rosterStudentsFixtures.threeRosterStudents} />
+      </BrowserRouter>
+    );
+
+    expectedHeaders.forEach((headerText) => {
+      expect(screen.getByText(headerText)).toBeInTheDocument();
+    });
+  });
+
+  test("renders expected field data for all rows", () => {
+    render(
+      <BrowserRouter>
+        <RosterStudentsTable rosterStudents={rosterStudentsFixtures.threeRosterStudents} />
+      </BrowserRouter>
+    );
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-firstName`)).toHaveTextContent("Shuang");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-lastName`)).toHaveTextContent("Li");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-email`)).toHaveTextContent("shuang@ucsb.edu");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-githubLogin`)).toHaveTextContent("aliceGH");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-githubId`)).toHaveTextContent("123456");
+
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-lastName`)).toHaveTextContent("Green");
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-email`)).toHaveTextContent("wendy@ucsb.edu");
+  });
+
+  test("does NOT show Edit/Delete buttons when showButtons is false explicitly", () => {
+    render(
+      <BrowserRouter>
+        <RosterStudentsTable
+          rosterStudents={rosterStudentsFixtures.threeRosterStudents}
+          showButtons={false}
+        />
+      </BrowserRouter>
+    );
+
+    expect(screen.queryByTestId(`${testId}-cell-row-0-col-Edit-button`)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(`${testId}-cell-row-0-col-Delete-button`)).not.toBeInTheDocument();
+  });
+
+  test("does NOT show Edit/Delete buttons when showButtons is omitted", () => {
+    render(
+      <BrowserRouter>
+        <RosterStudentsTable rosterStudents={rosterStudentsFixtures.threeRosterStudents} />
+      </BrowserRouter>
+    );
+
+    expect(screen.queryByTestId(`${testId}-cell-row-0-col-Edit-button`)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(`${testId}-cell-row-0-col-Delete-button`)).not.toBeInTheDocument();
+  });
+
+  test("shows Edit/Delete buttons and triggers alerts in storybook mode", async () => {
+    render(
+      <BrowserRouter>
+        <RosterStudentsTable
+          rosterStudents={rosterStudentsFixtures.threeRosterStudents}
+          showButtons={true}
+          storybook={true}
+        />
+      </BrowserRouter>
+    );
+
+    const editBtn = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    const deleteBtn = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+
+    fireEvent.click(editBtn);
+    fireEvent.click(deleteBtn);
+
+    await waitFor(() => {
+      expect(window.alert).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  test("Edit/Delete use console.log when not in storybook", () => {
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    render(
+      <BrowserRouter>
+        <RosterStudentsTable
+          rosterStudents={rosterStudentsFixtures.threeRosterStudents}
+          showButtons={true}
+          storybook={false}
+        />
+      </BrowserRouter>
+    );
+
+    fireEvent.click(screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`));
+    fireEvent.click(screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`));
+
+    expect(logSpy).toHaveBeenCalledWith("Edit clicked for row with id: 1");
+    expect(logSpy).toHaveBeenCalledWith("Delete clicked for row with id: 1");
+
+    logSpy.mockRestore();
+  });
+
+  test("edit/delete fallback when storybook is omitted (default false)", () => {
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    render(
+      <BrowserRouter>
+        <RosterStudentsTable
+          rosterStudents={rosterStudentsFixtures.threeRosterStudents}
+          showButtons={true}
+        />
+      </BrowserRouter>
+    );
+
+    fireEvent.click(screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`));
+    fireEvent.click(screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`));
+
+    expect(logSpy).toHaveBeenCalledWith("Edit clicked for row with id: 1");
+    expect(logSpy).toHaveBeenCalledWith("Delete clicked for row with id: 1");
+
+    logSpy.mockRestore();
+  });
+
+  test("Edit/Delete buttons have correct text and class", () => {
+    render(
+      <BrowserRouter>
+        <RosterStudentsTable
+          rosterStudents={rosterStudentsFixtures.threeRosterStudents}
+          showButtons={true}
+        />
+      </BrowserRouter>
+    );
+
+    const editBtn = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    const deleteBtn = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+
+    expect(editBtn).toHaveTextContent("Edit");
+    expect(editBtn).toHaveClass("btn-primary");
+    expect(deleteBtn).toHaveTextContent("Delete");
+    expect(deleteBtn).toHaveClass("btn-danger");
+  });
+});

--- a/frontend/src/tests/components/RosterStudents/RosterStudentsTable.test.js
+++ b/frontend/src/tests/components/RosterStudents/RosterStudentsTable.test.js
@@ -20,8 +20,10 @@ describe("RosterStudentsTable tests", () => {
 
     render(
       <BrowserRouter>
-        <RosterStudentsTable rosterStudents={rosterStudentsFixtures.threeRosterStudents} />
-      </BrowserRouter>
+        <RosterStudentsTable
+          rosterStudents={rosterStudentsFixtures.threeRosterStudents}
+        />
+      </BrowserRouter>,
     );
 
     expectedHeaders.forEach((headerText) => {
@@ -32,18 +34,34 @@ describe("RosterStudentsTable tests", () => {
   test("renders expected field data for all rows", () => {
     render(
       <BrowserRouter>
-        <RosterStudentsTable rosterStudents={rosterStudentsFixtures.threeRosterStudents} />
-      </BrowserRouter>
+        <RosterStudentsTable
+          rosterStudents={rosterStudentsFixtures.threeRosterStudents}
+        />
+      </BrowserRouter>,
     );
 
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-firstName`)).toHaveTextContent("Shuang");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-lastName`)).toHaveTextContent("Li");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-email`)).toHaveTextContent("shuang@ucsb.edu");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-githubLogin`)).toHaveTextContent("aliceGH");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-githubId`)).toHaveTextContent("123456");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-firstName`),
+    ).toHaveTextContent("Shuang");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-lastName`),
+    ).toHaveTextContent("Li");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-email`),
+    ).toHaveTextContent("shuang@ucsb.edu");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-githubLogin`),
+    ).toHaveTextContent("aliceGH");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-githubId`),
+    ).toHaveTextContent("123456");
 
-    expect(screen.getByTestId(`${testId}-cell-row-1-col-lastName`)).toHaveTextContent("Green");
-    expect(screen.getByTestId(`${testId}-cell-row-2-col-email`)).toHaveTextContent("wendy@ucsb.edu");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-lastName`),
+    ).toHaveTextContent("Green");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-2-col-email`),
+    ).toHaveTextContent("wendy@ucsb.edu");
   });
 
   test("does NOT show Edit/Delete buttons when showButtons is false explicitly", () => {
@@ -53,22 +71,32 @@ describe("RosterStudentsTable tests", () => {
           rosterStudents={rosterStudentsFixtures.threeRosterStudents}
           showButtons={false}
         />
-      </BrowserRouter>
+      </BrowserRouter>,
     );
 
-    expect(screen.queryByTestId(`${testId}-cell-row-0-col-Edit-button`)).not.toBeInTheDocument();
-    expect(screen.queryByTestId(`${testId}-cell-row-0-col-Delete-button`)).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId(`${testId}-cell-row-0-col-Edit-button`),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId(`${testId}-cell-row-0-col-Delete-button`),
+    ).not.toBeInTheDocument();
   });
 
   test("does NOT show Edit/Delete buttons when showButtons is omitted", () => {
     render(
       <BrowserRouter>
-        <RosterStudentsTable rosterStudents={rosterStudentsFixtures.threeRosterStudents} />
-      </BrowserRouter>
+        <RosterStudentsTable
+          rosterStudents={rosterStudentsFixtures.threeRosterStudents}
+        />
+      </BrowserRouter>,
     );
 
-    expect(screen.queryByTestId(`${testId}-cell-row-0-col-Edit-button`)).not.toBeInTheDocument();
-    expect(screen.queryByTestId(`${testId}-cell-row-0-col-Delete-button`)).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId(`${testId}-cell-row-0-col-Edit-button`),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId(`${testId}-cell-row-0-col-Delete-button`),
+    ).not.toBeInTheDocument();
   });
 
   test("shows Edit/Delete buttons and triggers alerts in storybook mode", async () => {
@@ -79,11 +107,13 @@ describe("RosterStudentsTable tests", () => {
           showButtons={true}
           storybook={true}
         />
-      </BrowserRouter>
+      </BrowserRouter>,
     );
 
     const editBtn = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
-    const deleteBtn = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    const deleteBtn = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
 
     fireEvent.click(editBtn);
     fireEvent.click(deleteBtn);
@@ -103,11 +133,13 @@ describe("RosterStudentsTable tests", () => {
           showButtons={true}
           storybook={false}
         />
-      </BrowserRouter>
+      </BrowserRouter>,
     );
 
     fireEvent.click(screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`));
-    fireEvent.click(screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`));
+    fireEvent.click(
+      screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`),
+    );
 
     expect(logSpy).toHaveBeenCalledWith("Edit clicked for row with id: 1");
     expect(logSpy).toHaveBeenCalledWith("Delete clicked for row with id: 1");
@@ -124,11 +156,13 @@ describe("RosterStudentsTable tests", () => {
           rosterStudents={rosterStudentsFixtures.threeRosterStudents}
           showButtons={true}
         />
-      </BrowserRouter>
+      </BrowserRouter>,
     );
 
     fireEvent.click(screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`));
-    fireEvent.click(screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`));
+    fireEvent.click(
+      screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`),
+    );
 
     expect(logSpy).toHaveBeenCalledWith("Edit clicked for row with id: 1");
     expect(logSpy).toHaveBeenCalledWith("Delete clicked for row with id: 1");
@@ -143,11 +177,13 @@ describe("RosterStudentsTable tests", () => {
           rosterStudents={rosterStudentsFixtures.threeRosterStudents}
           showButtons={true}
         />
-      </BrowserRouter>
+      </BrowserRouter>,
     );
 
     const editBtn = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
-    const deleteBtn = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    const deleteBtn = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
 
     expect(editBtn).toHaveTextContent("Edit");
     expect(editBtn).toHaveClass("btn-primary");


### PR DESCRIPTION
closes #26 
This PR added table component for RosterStudents, includes Edit and Delete buttons and tests
storybook link:
https://6823eb1f86c5af87fb88347a-qhunyddlct.chromatic.com/?path=/story/components-rosterstudents-rosterstudenttable--three-roster-students

![image](https://github.com/user-attachments/assets/6297b273-6eaf-4a84-b2f2-f2b836473dba)
