### PR TITLE
lm- POST and GET for Instructors Table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/InstructorsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/InstructorsController.java
@@ -1,0 +1,64 @@
+package edu.ucsb.cs156.frontiers.controllers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.ucsb.cs156.frontiers.entities.Instructor;
+import edu.ucsb.cs156.frontiers.repositories.InstructorRepository;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.extern.slf4j.Slf4j;
+
+@Tag(name = "Instructors")
+@RequestMapping("/api/instructors")
+@RestController
+@Slf4j
+
+public class InstructorsController extends ApiController{
+
+    @Autowired
+    InstructorRepository instructorRepository;
+
+    /**
+     * This method creates a new instructor. Accessible only to users with the role "ROLE_ADMIN".
+     * @param email email of the the instructor
+     * @return the new instructor
+     */
+    @Operation(summary= "Add a new Instructor")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public Instructor postInstructor(
+        @Parameter(name="email") @RequestParam String email
+        )
+        {
+
+        Instructor instructor = new Instructor(email);
+
+        Instructor savedInstructor = instructorRepository.save(instructor);
+
+        return savedInstructor;
+    }
+
+    /**
+     * THis method returns a list of all instructors.
+     * @return a list of all instructors
+     */
+    @Operation(summary= "List all Instructors")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/all")
+    public Iterable<Instructor> allInstructors() {
+        Iterable<Instructor> instructors = instructorRepository.findAll();
+        return instructors;
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/frontiers/controllers/InstructorsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/frontiers/controllers/InstructorsControllerTests.java
@@ -1,0 +1,111 @@
+package edu.ucsb.cs156.frontiers.controllers;
+
+import edu.ucsb.cs156.frontiers.repositories.UserRepository;
+import edu.ucsb.cs156.frontiers.testconfig.TestConfig;
+import edu.ucsb.cs156.frontiers.ControllerTestCase;
+import edu.ucsb.cs156.frontiers.entities.Instructor;
+import edu.ucsb.cs156.frontiers.repositories.InstructorRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.mockito.ArgumentCaptor;
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@WebMvcTest(controllers = InstructorsController.class)
+@Import(TestConfig.class)
+public class InstructorsControllerTests extends ControllerTestCase {
+
+    @MockBean
+    InstructorRepository instructorRepository;
+    @MockBean
+    UserRepository userRepository;
+
+    // Authorization tests for /api/ucsborganizations/post
+
+    @Test
+    public void logged_out_users_cannot_post() throws Exception {
+        mockMvc.perform(post("/api/instructors/post"))
+                .andExpect(status().is(403)); 
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_users_cannot_post() throws Exception {
+        mockMvc.perform(post("/api/instructors/post"))
+                .andExpect(status().is(403)); // only admins can post
+    }
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void logged_in_admins_can_post() throws Exception {
+        // arrange
+        Instructor expectedInstructor = new Instructor("test@ucsb.edu");
+        when(instructorRepository.save(any(Instructor.class))).thenReturn(expectedInstructor);
+
+        // act
+        MvcResult response = mockMvc.perform(post("/api/instructors/post?email=test@ucsb.edu").with(csrf()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        // assert
+        String expectedJson = mapper.writeValueAsString(expectedInstructor);
+        String actualResponse = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, actualResponse);
+    }
+
+    // Authorization tests for /api/instructors/admin/all
+    @Test
+    public void logged_out_users_cannot_get() throws Exception {
+        mockMvc.perform(get("/api/instructors/all"))
+                .andExpect(status().is(403)); // logged out users cannot get
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_users_cannot_get() throws Exception {
+        mockMvc.perform(get("/api/instructors/all"))
+                .andExpect(status().is(403)); // logged in users cannot get
+    }
+
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void logged_in_admins_can_get() throws Exception {
+        // arrage
+        Instructor instructor = Instructor.builder()
+                .email("test@ucsb.edu")
+                .build();
+
+        ArrayList<Instructor> expectedInstructors = new ArrayList<>(Arrays.asList(instructor));
+        when(instructorRepository.findAll()).thenReturn(expectedInstructors);
+        // act
+        MvcResult response = mockMvc.perform(get("/api/instructors/all"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        // assert
+        verify(instructorRepository, times(1)).findAll();
+        String expectedJson = mapper.writeValueAsString(expectedInstructors);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+}


### PR DESCRIPTION
This PR contains the implementation for POST and GET for the Instructors table. Delete still needs to be implemented.
UPDATE: Delete is now implemented in PR #41 
Try it out here: https://frontiers-dev-luismendoza25.dokku-11.cs.ucsb.edu/

<img width="663" alt="Screenshot 2025-05-20 at 1 29 25 AM" src="https://github.com/user-attachments/assets/56a35ab0-9c6c-4b05-ab56-f06cd4ed3221" />
