### PR TITLE
lm - instructors delete 

### DIFF
--- a/src/main/java/edu/ucsb/cs156/frontiers/controllers/InstructorsController.java
+++ b/src/main/java/edu/ucsb/cs156/frontiers/controllers/InstructorsController.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.frontiers.controllers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import edu.ucsb.cs156.frontiers.errors.EntityNotFoundException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import edu.ucsb.cs156.frontiers.entities.Instructor;
@@ -11,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -61,4 +63,22 @@ public class InstructorsController extends ApiController{
         Iterable<Instructor> instructors = instructorRepository.findAll();
         return instructors;
     }
+
+    /**
+     * This method deletes an instructor. Accessible only to users with the role "ROLE_ADMIN".
+     * @param email email of the instructor
+     * @return a message indicating the instructor was deleted
+     * */
+
+    @Operation(summary= "Delete an Instructor")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteInstructor(
+            @Parameter(name="email") @RequestParam String email) {
+        Instructor instructor = instructorRepository.findById(email)
+                .orElseThrow(() -> new EntityNotFoundException(Instructor.class, email));
+        instructorRepository.delete(instructor);
+        return genericMessage("Instructor with id %s deleted".formatted(email));
+    }
+
 }


### PR DESCRIPTION
This PR contains the delete operation for the instructors table.
This PR relies on PR #39, as it is an addition to these files. Merge #39 first.

Closes #3

Test at: https://frontiers-dev-luismendoza25.dokku-11.cs.ucsb.edu/
<img width="518" alt="Screenshot 2025-05-20 at 4 15 43 PM" src="https://github.com/user-attachments/assets/981eb928-791d-48b2-a971-f4f22e9f1dc4" />
